### PR TITLE
fix _sort_filelist call and function due to changes in PHP7

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -677,7 +677,7 @@ class syntax_plugin_filelist extends DokuWiki_Syntax_Plugin {
             $callback = array($this, '_compare_names');
             if ($params['order'] == 'desc') $reverseflag = true;
         }
-        $this->_sort_filelist($result['files'], $callback, $reverseflag);
+        $result['files'] = $this->_sort_filelist($result['files'], $callback, $reverseflag);
 
         // return the list
         if (count($result['files']) > 0)
@@ -710,6 +710,7 @@ class syntax_plugin_filelist extends DokuWiki_Syntax_Plugin {
         if ($reverse) {
             $files = array_reverse($files);
         }
+        return $files;
     }
 
     /**


### PR DESCRIPTION
The behavior of call by reference seams to be changed in PHP7. I changed a bit the _sort_filelist to return the sorted list.